### PR TITLE
Feature: Link Class

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # Flask-HAL
-Flask Extension to easily add support for REST HATEOAS via the HAL Specification: https://tools.ietf.org/html/draft-kelly-json-hal-07
+Flask Extension to easily add support for REST HATEOAS via the HAL Specification:
+https://tools.ietf.org/html/draft-kelly-json-hal-07
+
+## With Kim (ideas)
+
+``` python
+@app.route('/foo/:id')
+def foo_view(id):
+    foo = Foo.query.get(id)
+    data = FooSerializer().serialize(foo)
+
+    document = Document(links=Links(foo.hal_link()), data=data)
+
+    return document, 200
+```

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -8,6 +8,9 @@ flask_hal.link
 Implements the ``HAL`` Link specification.
 """
 
+# Standard Libs
+import json
+
 
 VALID_LINK_ATTRS = [
     'name',
@@ -60,6 +63,19 @@ class Link(object):
 
     def to_json(self):
         """Returns the ``JSON`` encoded representation of the ``Link`` object.
+
+        Returns:
+            str: The ``JSON`` encoded object
         """
 
-        pass
+        # Minimum viable link
+        link = {
+            'href': self.href
+        }
+
+        # Add extra attributes if they exist
+        for attr in VALID_LINK_ATTRS:
+            if hasattr(self, attr):
+                link[attr] = getattr(self, attr)
+
+        return json.dumps({self.rel: link})

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -23,7 +23,7 @@ VALID_LINK_ATTRS = [
 ]
 
 
-class Collection(object):
+class Collection(list):
     """Build a collection of ``HAL`` link objects.
 
     Example:
@@ -56,73 +56,12 @@ class Collection(object):
             TypeError: If a link is not a ``flask_hal.link.Link`` instance
         """
 
-        self.links = []
-        self.index = 0
-
         for link in args:
             if not isinstance(link, Link):
                 raise TypeError(
                     '{0} is not a valid flask_hal.link.Link instance'.format(link))
 
-            self.links.append(link)
-
-    def __getitem__(self, index):
-        """Get a specific link by index.
-        """
-
-        return self.links[index]
-
-    def __iter__(self):
-        """Makes the ``Collection`` object iterable.
-        """
-
-        return self
-
-    def __len__(self):
-        """Returns the number of links.
-        """
-
-        return len(self.links)
-
-    def __next__(self):
-        """Iterate to the next item.
-
-        Returns:
-            Link: The next link object
-
-        Raises:
-            StopIteration
-        """
-
-        try:
-            link = self.links[self.index]
-        except IndexError:
-            raise StopIteration
-        self.index += 1
-
-        return link
-
-    def next(self):
-        """Support for Python 2.x iterators.
-        """
-
-        return self.__next__()
-
-    def append(self, link):
-        """Appends a ``Link`` object to the ``Collection``.
-
-        Args:
-            link (flask_hal.link.Link): The ``Link`` object to add
-
-        Raises:
-            TypeError: If the ``link`` argument is not a ``flask_hal.link.Link``
-        """
-
-        if not isinstance(link, Link):
-            raise TypeError(
-                '{0} is not a valid flask_hal.link.Link instance'.format(link))
-
-        self.links.append(link)
+            self.append(link)
 
     def to_dict(self):
         """Returns the Python ``dict`` representation of the ``Collection``
@@ -143,7 +82,7 @@ class Collection(object):
 
         links = {}
 
-        for link in self.links:
+        for link in self:
             links.update(link.to_dict())
 
         return {

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -78,6 +78,12 @@ class Links(object):
 
         return self
 
+    def __len__(self):
+        """Returns the number of links.
+        """
+
+        return len(self.links)
+
     def __next__(self):
         """Iterate to the next item.
 

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -163,6 +163,33 @@ class Link(object):
             if attr in kwargs:
                 setattr(self, attr, kwargs.pop(attr))
 
+    def to_dict(self):
+        """Returns the Python ``dict`` representation of the ``Link`` instance.
+
+        Example:
+            >>> from flask_hal.link import Link
+            >>> l = Link('foo', 'http://foo.com')
+            >>> l.to_dict()
+            ... {'foo': {'href': 'http://foo.com'}}
+
+        Returns:
+            dict
+        """
+
+        # Minimum viable link
+        link = {
+            'href': self.href
+        }
+
+        # Add extra attributes if they exist
+        for attr in VALID_LINK_ATTRS:
+            if hasattr(self, attr):
+                link[attr] = getattr(self, attr)
+
+        return {
+            self.rel: link
+        }
+
     def to_json(self):
         """Returns the ``JSON`` encoded representation of the ``Link`` object.
 
@@ -176,14 +203,4 @@ class Link(object):
             str: The ``JSON`` encoded object
         """
 
-        # Minimum viable link
-        link = {
-            'href': self.href
-        }
-
-        # Add extra attributes if they exist
-        for attr in VALID_LINK_ATTRS:
-            if hasattr(self, attr):
-                link[attr] = getattr(self, attr)
-
-        return json.dumps({self.rel: link})
+        return json.dumps(self.to_dict())

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -66,6 +66,12 @@ class Links(object):
 
             self.links.append(link)
 
+    def __getitem__(self, index):
+        """Get a specific link by index.
+        """
+
+        return self.links[index]
+
     def __iter__(self):
         """Makes the ``Links`` object iterable.
         """

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -166,6 +166,12 @@ class Link(object):
     def to_json(self):
         """Returns the ``JSON`` encoded representation of the ``Link`` object.
 
+        Example:
+            >>> from flask_hal.link import Link
+            >>> l = Link('foo', 'http://foo.com', name='Foo')
+            >>> print l.to_json()
+            ... '{"foo": {"href": "http://foo.com", "name": "Foo"}}'
+
         Returns:
             str: The ``JSON`` encoded object
         """

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -23,32 +23,32 @@ VALID_LINK_ATTRS = [
 ]
 
 
-class Links(object):
+class Collection(object):
     """Build a collection of ``HAL`` link objects.
 
     Example:
-        >>> from flask_hal.link import Link, Links
-        >>> l = Links(
+        >>> from flask_hal.link import Collection, Link
+        >>> l = Collection(
         ...     Link('foo', 'http://foo.com'),
         ...     Link('bar', 'http://bar.com'))
-        >>> print l.to_json()
+        >>> print l.to_dict()
         ... {
-        ...     "_links": {
-        ...         "foo": {
-        ...             "href": "http://foo.com"
+        ...     '_links': {
+        ...         'foo': {
+        ...             'href": "http://foo.com'
         ...         },
-        ...         "bar": {
-        ...             "href": "http://bar.com"
+        ...         'bar': {
+        ...             'href': 'http://bar.com'
         ...         }
         ...     }
         ... }
     """
 
     def __init__(self, *args):
-        """Initialise a new ``Links`` object.
+        """Initialise a new ``Collection`` object.
 
         Example:
-            >>> l = Links(
+            >>> l = Collection(
             ...     Link('foo', 'http://foo.com'),
             ...     Link('bar', 'http://bar.com'))
 
@@ -73,7 +73,7 @@ class Links(object):
         return self.links[index]
 
     def __iter__(self):
-        """Makes the ``Links`` object iterable.
+        """Makes the ``Collection`` object iterable.
         """
 
         return self
@@ -109,7 +109,7 @@ class Links(object):
         return self.__next__()
 
     def append(self, link):
-        """Appends a ``Link`` object to the ``Links``.
+        """Appends a ``Link`` object to the ``Collection``.
 
         Args:
             link (flask_hal.link.Link): The ``Link`` object to add
@@ -125,11 +125,12 @@ class Links(object):
         self.links.append(link)
 
     def to_dict(self):
-        """Returns the Python ``dict`` representation of the ``Links`` instance.
+        """Returns the Python ``dict`` representation of the ``Collection``
+        instance.
 
         Example:
-            >>> from flask_hal.link import Link, Links
-            >>> l = Links(
+            >>> from flask_hal.link import Collection, Link
+            >>> l = Collection(
             ...     Link('foo', 'http://foo.com'),
             ...     Link('bar', 'http://bar.com'))
             >>> l.to_dict()
@@ -153,8 +154,8 @@ class Links(object):
         """Returns the ``JSON`` representation of the instance.
 
         Example:
-            >>> from flask_hal.link import Link, Links
-            >>> l = Links(
+            >>> from flask_hal.link import Collection, Link
+            >>> l = Collection(
             ...     Link('foo', 'http://foo.com'),
             ...     Link('bar', 'http://bar.com'))
             >>> l.to_json()

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+"""
+flask_hal.link
+==============
+
+Implements the ``HAL`` Link specification.
+"""
+
+
+class Link(object):
+    """
+    """
+
+    def __init__(
+            self,
+            href,
+            name=None,
+            title=None,
+            link_type=None,
+            deprecation=None,
+            profile=None,
+            templated=None,
+            hreflang=None):
+        """
+        """
+
+        self.href = href
+        self.name = name
+        self.title = title
+        self.link_type = link_type,
+        self.deprecation = deprecation
+        self.profile = profile
+        self.templated = templated
+        self.hreflang = hreflang

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -124,6 +124,48 @@ class Links(object):
 
         self.links.append(link)
 
+    def to_dict(self):
+        """Returns the Python ``dict`` representation of the ``Links`` instance.
+
+        Example:
+            >>> from flask_hal.link import Link, Links
+            >>> l = Links(
+            ...     Link('foo', 'http://foo.com'),
+            ...     Link('bar', 'http://bar.com'))
+            >>> l.to_dict()
+            ... {'_links': {'bar': {'href': 'http://bar.com'},
+            ... 'foo': {'href': 'http://foo.com'}}}
+
+        Returns:
+            dict
+        """
+
+        links = {}
+
+        for link in self.links:
+            links.update(link.to_dict())
+
+        return {
+            '_links': links
+        }
+
+    def to_json(self):
+        """Returns the ``JSON`` representation of the instance.
+
+        Example:
+            >>> from flask_hal.link import Link, Links
+            >>> l = Links(
+            ...     Link('foo', 'http://foo.com'),
+            ...     Link('bar', 'http://bar.com'))
+            >>> l.to_json()
+            ... '{"_links": {"foo": {"href": "http://foo.com"}, "bar": {"href": "http://bar.com"}}}'
+
+        Returns:
+            str: The ``JSON`` representation of the instance
+        """
+
+        return json.dumps(self.to_dict())
+
 
 class Link(object):
     """Build ``HAL`` specification ``_links`` object.

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -57,10 +57,41 @@ class Links(object):
         """
 
         self.links = []
+        self.index = 0
 
         for link in args:
             if isinstance(link, Link):
-                self.links.append = link
+                self.links.append(link)
+
+    def __iter__(self):
+        """Makes the ``Links`` object iterable.
+        """
+
+        return self
+
+    def __next__(self):
+        """Iterate to the next item.
+
+        Returns:
+            Link: The next link object
+
+        Raises:
+            StopIteration
+        """
+
+        try:
+            link = self.links[self.index]
+        except IndexError:
+            raise StopIteration
+        self.index += 1
+
+        return link
+
+    def next(self):
+        """Support for Python 2.x iterators.
+        """
+
+        return self.__next__()
 
 
 class Link(object):

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -44,7 +44,23 @@ class Links(object):
         ... }
     """
 
-    pass
+    def __init__(self, *args):
+        """Initialise a new ``Links`` object.
+
+        Example:
+            >>> l = Links(
+            ...     Link('foo', 'http://foo.com'),
+            ...     Link('bar', 'http://bar.com'))
+
+        Note:
+            Links that are not instances of ``Link`` will be ignored.
+        """
+
+        self.links = []
+
+        for link in args:
+            if isinstance(link, Link):
+                self.links.append = link
 
 
 class Link(object):

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -23,6 +23,30 @@ VALID_LINK_ATTRS = [
 ]
 
 
+class Links(object):
+    """Build a collection of ``HAL`` link objects.
+
+    Example:
+        >>> from flask_hal.link import Link, Links
+        >>> l = Links(
+        ...     Link('foo', 'http://foo.com'),
+        ...     Link('bar', 'http://bar.com'))
+        >>> print l.to_json()
+        ... {
+        ...     "_links": {
+        ...         "foo": {
+        ...             "href": "http://foo.com"
+        ...         },
+        ...         "bar": {
+        ...             "href": "http://bar.com"
+        ...         }
+        ...     }
+        ... }
+    """
+
+    pass
+
+
 class Link(object):
     """Build ``HAL`` specification ``_links`` object.
 

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -52,16 +52,19 @@ class Links(object):
             ...     Link('foo', 'http://foo.com'),
             ...     Link('bar', 'http://bar.com'))
 
-        Note:
-            Links that are not instances of ``Link`` will be ignored.
+        Raises:
+            TypeError: If a link is not a ``flask_hal.link.Link`` instance
         """
 
         self.links = []
         self.index = 0
 
         for link in args:
-            if isinstance(link, Link):
-                self.links.append(link)
+            if not isinstance(link, Link):
+                raise TypeError(
+                    '{0} is not a valid flask_hal.link.Link instance'.format(link))
+
+            self.links.append(link)
 
     def __iter__(self):
         """Makes the ``Links`` object iterable.

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -93,6 +93,22 @@ class Links(object):
 
         return self.__next__()
 
+    def append(self, link):
+        """Appends a ``Link`` object to the ``Links``.
+
+        Args:
+            link (flask_hal.link.Link): The ``Link`` object to add
+
+        Raises:
+            TypeError: If the ``link`` argument is not a ``flask_hal.link.Link``
+        """
+
+        if not isinstance(link, Link):
+            raise TypeError(
+                '{0} is not a valid flask_hal.link.Link instance'.format(link))
+
+        self.links.append(link)
+
 
 class Link(object):
     """Build ``HAL`` specification ``_links`` object.

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -9,28 +9,57 @@ Implements the ``HAL`` Link specification.
 """
 
 
+VALID_LINK_ATTRS = [
+    'name',
+    'title',
+    'type',
+    'deprecation',
+    'profile',
+    'templated',
+    'hreflang'
+]
+
+
 class Link(object):
-    """
+    """Build ``HAL`` specification ``_links`` object.
+
+    Example:
+        >>> from flask_hal.link import Link
+        >>> l = Link('foo', 'http://foo.com/bar')
+        >>> print l.to_json()
+        ... '{"foo": {"href": "http://foo.com/bar"}}'
+        >>> l.title = 'Foo'
+        >>> print l.to_json()
+        ... '{"foo": {"href": "http://foo.com/bar", "name": "Foo"}}'
+
     """
 
-    def __init__(
-            self,
-            href,
-            name=None,
-            title=None,
-            link_type=None,
-            deprecation=None,
-            profile=None,
-            templated=None,
-            hreflang=None):
-        """
+    def __init__(self, rel, href, **kwargs):
+        """Initialise a new ``Link`` object.
+
+        Args:
+            rel (str): The links ``rel`` or name
+            href (str): The URI to the resource
+
+        Keyword Args:
+            name (str): The links name attribute, optional
+            title (str): The links title attribute, optional
+            type (str): The links type attribute, optional
+            deprecation (str): The deprecation attribute, optional
+            profile (str): The profile  attribute, optional
+            templated (bool): The templated attribute, optional
+            hreflang (str): The hreflang attribute, optional
         """
 
+        self.rel = rel
         self.href = href
-        self.name = name
-        self.title = title
-        self.link_type = link_type,
-        self.deprecation = deprecation
-        self.profile = profile
-        self.templated = templated
-        self.hreflang = hreflang
+
+        for attr in VALID_LINK_ATTRS:
+            if attr in kwargs:
+                setattr(self, attr, kwargs.pop(attr))
+
+    def to_json(self):
+        """Returns the ``JSON`` encoded representation of the ``Link`` object.
+        """
+
+        pass


### PR DESCRIPTION
Adds a `Link` and `Links` class allowing us to build `HAL` links easily.

The intended usage will eventually be something like:

``` python
from flask_hal import Document, Link, Links

d = Document(links=Links(Link('foo', '/foo'), Link('bar', '/bar')))
d.links.append(Link('baz', '/baz'))

d.links.to_json()
'{"_links": {"foo": {"href": "/foo"}, "bar": {"href": "/bar"}, "baz": {"href": "/baz"}}}'

d.links[0].name = 'Foo'
d.links.to_json()
'{"_links": {"foo": {"href": "/foo", "name": "Foo"}, "bar": {"href": "/bar"}, "baz": {"href": "/baz"}}}'
```
