### PR TITLE
Feature: Document API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,8 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Mr Developer
+.tmuxp.yaml
+.env
+fugu.yml

--- a/Dockerfile.py27
+++ b/Dockerfile.py27
@@ -1,0 +1,4 @@
+FROM ubuntu:14.04
+
+RUN apt-get update && apt-get install software-properties-common -y
+RUN add-apt-repository ppa:fkrull/deadsnakes -y && apt-get update && apt-get install python2.7 -y

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # Flask-HAL
-Flask Extension to easily add support for REST HATEOAS via the HAL Specification: https://tools.ietf.org/html/draft-kelly-json-hal-07
+Flask Extension to easily add support for REST HATEOAS via the HAL Specification:
+https://tools.ietf.org/html/draft-kelly-json-hal-07
+
+## With Kim (ideas)
+
+``` python
+@app.route('/foo/:id')
+def foo_view(id):
+    foo = Foo.query.get(id)
+    data = FooSerializer().serialize(foo)
+
+    document = Document(links=Links(foo.hal_link()), data=data)
+
+    return document, 200
+```

--- a/flask_hal/__init__.py
+++ b/flask_hal/__init__.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+"""
+flask_hal
+=========
+
+Flask-HAL provides support for the ``HAL`` Specification within Flask allowing
+you to build ``REST`` API responses which fulfil this specification.
+
+Read more at the `Official Draft <https://tools.ietf.org/html/draft-kelly-json-hal-07>`_
+"""
+
+
+class HAL(object):
+    """Enables Flask-HAL integration into Flask Applications, either by the
+    Application Factory Pattern or directly into an already created Flask
+    Application instance.
+
+    This will set a custom ``response_class`` for the Application which
+    handles the conversion of a ``HAL`` document response from a
+    view into it's ``JSON`` representation.
+    """
+
+    def __init__(self, app=None, response_class=None):
+        """Initialise Flask-HAL with a Flask Application. Acts as a proxy
+        to :meth:`flask_hal.HAL.init_app`.
+
+        Example:
+            >>> from flask import Flask
+            >>> from flask_hal import HAL
+            >>> app = Flask(__name__)
+            >>> HAL(app=app)
+
+        Keyword Args:
+            app (flask.app.Flask): Optional Flask application instance
+            response_class (class): Optional custom ``response_class``
+        """
+
+        if app is not None:
+            self.init_app(app, response_class=response_class)
+
+    def init_app(self, app, response_class=None):
+        """Initialise Flask-HAL with a Flask Application. This is designed to
+        be used with the Flask Application Factory Pattern.
+
+        Example:
+            >>> from flask import Flask
+            >>> from flask_hal import HAL
+            >>> app = Flask(__name__)
+            >>> HAL().init_app(app)
+
+        Args:
+            app (flask.app.Flask): Flask application instance
+
+        Keyword Args:
+            response_class (class): Optional custom ``response_class``
+        """
+
+        pass

--- a/flask_hal/document.py
+++ b/flask_hal/document.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+"""
+flask_hal.document
+==================
+
+Module for constructing ``HAL`` documents.
+
+Example:
+    >>> from flask_hal.document import Document
+    >>> d = Document()
+    >>> d.to_dict()
+"""
+
+# Third Party Libs
+from flask_hal import link
+
+
+class Document(object):
+    """Constructs a ``HAL`` document.
+    """
+
+    def __init__(self, data=None, links=None, embedded=None):
+        """Initialises a new ``HAL`` Document instance. If no arguments are
+        proviced a minimal viable ``HAL`` Document is created.
+
+        Keyword Args:
+            data (dict): Data for the document
+            links (flask_hal.link.Collection): A collection of ``HAL`` links
+            embedded: TBC
+        """
+
+        self.data = data
+        self.embedded = embedded  # TODO: Embedded API TBC
+
+        # No links proviced, create an empty collection
+        if links is None:
+            links = link.Collection()
+
+        # Always add the self link
+        links.append(link.Self())
+
+        self.links = links

--- a/flask_hal/document.py
+++ b/flask_hal/document.py
@@ -29,6 +29,9 @@ class Document(object):
             data (dict): Data for the document
             links (flask_hal.link.Collection): A collection of ``HAL`` links
             embedded: TBC
+
+        Raises:
+            TypeError: If ``links`` is not a :class:`flask_hal.link.Collection`
         """
 
         self.data = data
@@ -37,6 +40,9 @@ class Document(object):
         # No links proviced, create an empty collection
         if links is None:
             links = link.Collection()
+        else:
+            if not isinstance(links, link.Collection):
+                raise TypeError('links must be a flask_hal.link.Collection instance')
 
         # Always add the self link
         links.append(link.Self())

--- a/flask_hal/document.py
+++ b/flask_hal/document.py
@@ -13,6 +13,9 @@ Example:
     >>> d.to_dict()
 """
 
+# Standard Libs
+import json
+
 # Third Party Libs
 from flask_hal import link
 
@@ -70,3 +73,12 @@ class Document(object):
         document.update(self.embedded)
 
         return document
+
+    def to_json(self):
+        """Converts :class:`.Document` to a ``JSON`` datastrucute.
+
+        Returns:
+            str: ``JSON`` document
+        """
+
+        return json.dumps(self.to_dict())

--- a/flask_hal/document.py
+++ b/flask_hal/document.py
@@ -26,7 +26,7 @@ class Document(object):
 
     def __init__(self, data=None, links=None, embedded=None):
         """Initialises a new ``HAL`` Document instance. If no arguments are
-        proviced a minimal viable ``HAL`` Document is created.
+        provided a minimal viable ``HAL`` Document is created.
 
         Keyword Args:
             data (dict): Data for the document
@@ -40,7 +40,7 @@ class Document(object):
         self.data = data
         self.embedded = embedded  # TODO: Embedded API TBC
 
-        # No links proviced, create an empty collection
+        # No links provided, create an empty collection
         if links is None:
             links = link.Collection()
         else:
@@ -54,7 +54,7 @@ class Document(object):
 
     def to_dict(self):
         """Converts the ``Document`` instance into an appropriate data
-        strucutre for HAL formatted documents.
+        structure for HAL formatted documents.
 
         Returns:
             dict: The ``HAL`` document data structure
@@ -69,13 +69,13 @@ class Document(object):
         # Add Links
         document.update(self.links.to_dict())
 
-        # Add Embeded TODO: Embedded API TBC
+        # Add Embedded TODO: Embedded API TBC
         document.update(self.embedded)
 
         return document
 
     def to_json(self):
-        """Converts :class:`.Document` to a ``JSON`` datastrucute.
+        """Converts :class:`.Document` to a ``JSON`` data structure.
 
         Returns:
             str: ``JSON`` document

--- a/flask_hal/document.py
+++ b/flask_hal/document.py
@@ -48,3 +48,25 @@ class Document(object):
         links.append(link.Self())
 
         self.links = links
+
+    def to_dict(self):
+        """Converts the ``Document`` instance into an appropriate data
+        strucutre for HAL formatted documents.
+
+        Returns:
+            dict: The ``HAL`` document data structure
+        """
+
+        document = {}
+
+        # Add Data to the Document
+        if isinstance(self.data, dict):
+            document.update(self.data)
+
+        # Add Links
+        document.update(self.links.to_dict())
+
+        # Add Embeded TODO: Embedded API TBC
+        document.update(self.embedded)
+
+        return document

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -8,6 +8,9 @@ flask_hal.link
 Implements the ``HAL`` Link specification.
 """
 
+# Standard Libs
+import json
+
 
 VALID_LINK_ATTRS = [
     'name',
@@ -60,6 +63,19 @@ class Link(object):
 
     def to_json(self):
         """Returns the ``JSON`` encoded representation of the ``Link`` object.
+
+        Returns:
+            str: The ``JSON`` encoded object
         """
 
-        pass
+        # Minimum viable link
+        link = {
+            'href': self.href
+        }
+
+        # Add extra attributes if they exist
+        for attr in VALID_LINK_ATTRS:
+            if hasattr(self, attr):
+                link[attr] = getattr(self, attr)
+
+        return json.dumps({self.rel: link})

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -78,6 +78,12 @@ class Links(object):
 
         return self
 
+    def __len__(self):
+        """Returns the number of links.
+        """
+
+        return len(self.links)
+
     def __next__(self):
         """Iterate to the next item.
 

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -163,6 +163,33 @@ class Link(object):
             if attr in kwargs:
                 setattr(self, attr, kwargs.pop(attr))
 
+    def to_dict(self):
+        """Returns the Python ``dict`` representation of the ``Link`` instance.
+
+        Example:
+            >>> from flask_hal.link import Link
+            >>> l = Link('foo', 'http://foo.com')
+            >>> l.to_dict()
+            ... {'foo': {'href': 'http://foo.com'}}
+
+        Returns:
+            dict
+        """
+
+        # Minimum viable link
+        link = {
+            'href': self.href
+        }
+
+        # Add extra attributes if they exist
+        for attr in VALID_LINK_ATTRS:
+            if hasattr(self, attr):
+                link[attr] = getattr(self, attr)
+
+        return {
+            self.rel: link
+        }
+
     def to_json(self):
         """Returns the ``JSON`` encoded representation of the ``Link`` object.
 
@@ -176,14 +203,4 @@ class Link(object):
             str: The ``JSON`` encoded object
         """
 
-        # Minimum viable link
-        link = {
-            'href': self.href
-        }
-
-        # Add extra attributes if they exist
-        for attr in VALID_LINK_ATTRS:
-            if hasattr(self, attr):
-                link[attr] = getattr(self, attr)
-
-        return json.dumps({self.rel: link})
+        return json.dumps(self.to_dict())

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -66,6 +66,12 @@ class Links(object):
 
             self.links.append(link)
 
+    def __getitem__(self, index):
+        """Get a specific link by index.
+        """
+
+        return self.links[index]
+
     def __iter__(self):
         """Makes the ``Links`` object iterable.
         """

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -11,6 +11,9 @@ Implements the ``HAL`` Link specification.
 # Standard Libs
 import json
 
+# Third Party Libs
+from flask import request
+
 
 VALID_LINK_ATTRS = [
     'name',
@@ -247,3 +250,19 @@ class Link(object):
         """
 
         return json.dumps(self.to_dict())
+
+
+class Self(Link):
+    """A class to create the required ``self`` link  from the current
+    request URL.
+    """
+
+    def __init__(self, **kwargs):
+        """Initialises a new ``Self`` link instance. Accepts the same
+        Keyword Arguments as :class:`.Link`.
+
+        See Also:
+            :class:`.Link`
+        """
+
+        return super(Self, self).__init__('self', request.url, **kwargs)

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -166,6 +166,12 @@ class Link(object):
     def to_json(self):
         """Returns the ``JSON`` encoded representation of the ``Link`` object.
 
+        Example:
+            >>> from flask_hal.link import Link
+            >>> l = Link('foo', 'http://foo.com', name='Foo')
+            >>> print l.to_json()
+            ... '{"foo": {"href": "http://foo.com", "name": "Foo"}}'
+
         Returns:
             str: The ``JSON`` encoded object
         """

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -23,32 +23,32 @@ VALID_LINK_ATTRS = [
 ]
 
 
-class Links(object):
+class Collection(object):
     """Build a collection of ``HAL`` link objects.
 
     Example:
-        >>> from flask_hal.link import Link, Links
-        >>> l = Links(
+        >>> from flask_hal.link import Collection, Link
+        >>> l = Collection(
         ...     Link('foo', 'http://foo.com'),
         ...     Link('bar', 'http://bar.com'))
-        >>> print l.to_json()
+        >>> print l.to_dict()
         ... {
-        ...     "_links": {
-        ...         "foo": {
-        ...             "href": "http://foo.com"
+        ...     '_links': {
+        ...         'foo': {
+        ...             'href": "http://foo.com'
         ...         },
-        ...         "bar": {
-        ...             "href": "http://bar.com"
+        ...         'bar': {
+        ...             'href': 'http://bar.com'
         ...         }
         ...     }
         ... }
     """
 
     def __init__(self, *args):
-        """Initialise a new ``Links`` object.
+        """Initialise a new ``Collection`` object.
 
         Example:
-            >>> l = Links(
+            >>> l = Collection(
             ...     Link('foo', 'http://foo.com'),
             ...     Link('bar', 'http://bar.com'))
 
@@ -73,7 +73,7 @@ class Links(object):
         return self.links[index]
 
     def __iter__(self):
-        """Makes the ``Links`` object iterable.
+        """Makes the ``Collection`` object iterable.
         """
 
         return self
@@ -109,7 +109,7 @@ class Links(object):
         return self.__next__()
 
     def append(self, link):
-        """Appends a ``Link`` object to the ``Links``.
+        """Appends a ``Link`` object to the ``Collection``.
 
         Args:
             link (flask_hal.link.Link): The ``Link`` object to add
@@ -125,11 +125,12 @@ class Links(object):
         self.links.append(link)
 
     def to_dict(self):
-        """Returns the Python ``dict`` representation of the ``Links`` instance.
+        """Returns the Python ``dict`` representation of the ``Collection``
+        instance.
 
         Example:
-            >>> from flask_hal.link import Link, Links
-            >>> l = Links(
+            >>> from flask_hal.link import Collection, Link
+            >>> l = Collection(
             ...     Link('foo', 'http://foo.com'),
             ...     Link('bar', 'http://bar.com'))
             >>> l.to_dict()
@@ -153,8 +154,8 @@ class Links(object):
         """Returns the ``JSON`` representation of the instance.
 
         Example:
-            >>> from flask_hal.link import Link, Links
-            >>> l = Links(
+            >>> from flask_hal.link import Collection, Link
+            >>> l = Collection(
             ...     Link('foo', 'http://foo.com'),
             ...     Link('bar', 'http://bar.com'))
             >>> l.to_json()

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+"""
+flask_hal.link
+==============
+
+Implements the ``HAL`` Link specification.
+"""
+
+
+class Link(object):
+    """
+    """
+
+    def __init__(
+            self,
+            href,
+            name=None,
+            title=None,
+            link_type=None,
+            deprecation=None,
+            profile=None,
+            templated=None,
+            hreflang=None):
+        """
+        """
+
+        self.href = href
+        self.name = name
+        self.title = title
+        self.link_type = link_type,
+        self.deprecation = deprecation
+        self.profile = profile
+        self.templated = templated
+        self.hreflang = hreflang

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -124,6 +124,48 @@ class Links(object):
 
         self.links.append(link)
 
+    def to_dict(self):
+        """Returns the Python ``dict`` representation of the ``Links`` instance.
+
+        Example:
+            >>> from flask_hal.link import Link, Links
+            >>> l = Links(
+            ...     Link('foo', 'http://foo.com'),
+            ...     Link('bar', 'http://bar.com'))
+            >>> l.to_dict()
+            ... {'_links': {'bar': {'href': 'http://bar.com'},
+            ... 'foo': {'href': 'http://foo.com'}}}
+
+        Returns:
+            dict
+        """
+
+        links = {}
+
+        for link in self.links:
+            links.update(link.to_dict())
+
+        return {
+            '_links': links
+        }
+
+    def to_json(self):
+        """Returns the ``JSON`` representation of the instance.
+
+        Example:
+            >>> from flask_hal.link import Link, Links
+            >>> l = Links(
+            ...     Link('foo', 'http://foo.com'),
+            ...     Link('bar', 'http://bar.com'))
+            >>> l.to_json()
+            ... '{"_links": {"foo": {"href": "http://foo.com"}, "bar": {"href": "http://bar.com"}}}'
+
+        Returns:
+            str: The ``JSON`` representation of the instance
+        """
+
+        return json.dumps(self.to_dict())
+
 
 class Link(object):
     """Build ``HAL`` specification ``_links`` object.

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -57,10 +57,41 @@ class Links(object):
         """
 
         self.links = []
+        self.index = 0
 
         for link in args:
             if isinstance(link, Link):
-                self.links.append = link
+                self.links.append(link)
+
+    def __iter__(self):
+        """Makes the ``Links`` object iterable.
+        """
+
+        return self
+
+    def __next__(self):
+        """Iterate to the next item.
+
+        Returns:
+            Link: The next link object
+
+        Raises:
+            StopIteration
+        """
+
+        try:
+            link = self.links[self.index]
+        except IndexError:
+            raise StopIteration
+        self.index += 1
+
+        return link
+
+    def next(self):
+        """Support for Python 2.x iterators.
+        """
+
+        return self.__next__()
 
 
 class Link(object):

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -44,7 +44,23 @@ class Links(object):
         ... }
     """
 
-    pass
+    def __init__(self, *args):
+        """Initialise a new ``Links`` object.
+
+        Example:
+            >>> l = Links(
+            ...     Link('foo', 'http://foo.com'),
+            ...     Link('bar', 'http://bar.com'))
+
+        Note:
+            Links that are not instances of ``Link`` will be ignored.
+        """
+
+        self.links = []
+
+        for link in args:
+            if isinstance(link, Link):
+                self.links.append = link
 
 
 class Link(object):

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -23,6 +23,30 @@ VALID_LINK_ATTRS = [
 ]
 
 
+class Links(object):
+    """Build a collection of ``HAL`` link objects.
+
+    Example:
+        >>> from flask_hal.link import Link, Links
+        >>> l = Links(
+        ...     Link('foo', 'http://foo.com'),
+        ...     Link('bar', 'http://bar.com'))
+        >>> print l.to_json()
+        ... {
+        ...     "_links": {
+        ...         "foo": {
+        ...             "href": "http://foo.com"
+        ...         },
+        ...         "bar": {
+        ...             "href": "http://bar.com"
+        ...         }
+        ...     }
+        ... }
+    """
+
+    pass
+
+
 class Link(object):
     """Build ``HAL`` specification ``_links`` object.
 

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -52,16 +52,19 @@ class Links(object):
             ...     Link('foo', 'http://foo.com'),
             ...     Link('bar', 'http://bar.com'))
 
-        Note:
-            Links that are not instances of ``Link`` will be ignored.
+        Raises:
+            TypeError: If a link is not a ``flask_hal.link.Link`` instance
         """
 
         self.links = []
         self.index = 0
 
         for link in args:
-            if isinstance(link, Link):
-                self.links.append(link)
+            if not isinstance(link, Link):
+                raise TypeError(
+                    '{0} is not a valid flask_hal.link.Link instance'.format(link))
+
+            self.links.append(link)
 
     def __iter__(self):
         """Makes the ``Links`` object iterable.

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -93,6 +93,22 @@ class Links(object):
 
         return self.__next__()
 
+    def append(self, link):
+        """Appends a ``Link`` object to the ``Links``.
+
+        Args:
+            link (flask_hal.link.Link): The ``Link`` object to add
+
+        Raises:
+            TypeError: If the ``link`` argument is not a ``flask_hal.link.Link``
+        """
+
+        if not isinstance(link, Link):
+            raise TypeError(
+                '{0} is not a valid flask_hal.link.Link instance'.format(link))
+
+        self.links.append(link)
+
 
 class Link(object):
     """Build ``HAL`` specification ``_links`` object.

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -9,28 +9,57 @@ Implements the ``HAL`` Link specification.
 """
 
 
+VALID_LINK_ATTRS = [
+    'name',
+    'title',
+    'type',
+    'deprecation',
+    'profile',
+    'templated',
+    'hreflang'
+]
+
+
 class Link(object):
-    """
+    """Build ``HAL`` specification ``_links`` object.
+
+    Example:
+        >>> from flask_hal.link import Link
+        >>> l = Link('foo', 'http://foo.com/bar')
+        >>> print l.to_json()
+        ... '{"foo": {"href": "http://foo.com/bar"}}'
+        >>> l.title = 'Foo'
+        >>> print l.to_json()
+        ... '{"foo": {"href": "http://foo.com/bar", "name": "Foo"}}'
+
     """
 
-    def __init__(
-            self,
-            href,
-            name=None,
-            title=None,
-            link_type=None,
-            deprecation=None,
-            profile=None,
-            templated=None,
-            hreflang=None):
-        """
+    def __init__(self, rel, href, **kwargs):
+        """Initialise a new ``Link`` object.
+
+        Args:
+            rel (str): The links ``rel`` or name
+            href (str): The URI to the resource
+
+        Keyword Args:
+            name (str): The links name attribute, optional
+            title (str): The links title attribute, optional
+            type (str): The links type attribute, optional
+            deprecation (str): The deprecation attribute, optional
+            profile (str): The profile  attribute, optional
+            templated (bool): The templated attribute, optional
+            hreflang (str): The hreflang attribute, optional
         """
 
+        self.rel = rel
         self.href = href
-        self.name = name
-        self.title = title
-        self.link_type = link_type,
-        self.deprecation = deprecation
-        self.profile = profile
-        self.templated = templated
-        self.hreflang = hreflang
+
+        for attr in VALID_LINK_ATTRS:
+            if attr in kwargs:
+                setattr(self, attr, kwargs.pop(attr))
+
+    def to_json(self):
+        """Returns the ``JSON`` encoded representation of the ``Link`` object.
+        """
+
+        pass


### PR DESCRIPTION
This is dependant on #1 being merged first.

Implements a simpler document building API which allows us to return a well formed `HAL` document for serialisation.

**Note**: This dosn't yet have the custom response class which would auto tip the document as JSON

``` python
# Third Party Libs
from flask import Flask
from flask_hal import HAL, document


app = Flask(__name__)
HAL(app)  # Initialise HAL


@app.route('/foo')
def foo():
    d = document.Document(data={
        'foo': 'bar'
    })

    return d.to_json()

if __name__ == "__main__":
    app.run()
```

``` http
GET / HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate
Connection: keep-alive
Host: google.com
User-Agent: HTTPie/0.9.2

HTTP/1.1 200 OK
Content-Type: application/json; charset=UTF-8
Date: Thu, 06 Aug 2015 10:24:04 GMT

{
    "_links": {
        "self": {
            "href": "/foo"
        },
    },
    "foo": "bar"
}
```
