### PR TITLE
Feature: Response Class

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,9 @@
+[settings]
+line_length=80
+multi_line_output=3
+known_first_party=flask_hal
+default_section=THIRDPARTY
+import_heading_stdlib=Standard Libs
+import_heading_thirdparty=Third Party Libs
+import_heading_firstparty=First Party Libs
+lines_after_imports=2

--- a/examples/hello_world/hello_world.py
+++ b/examples/hello_world/hello_world.py
@@ -8,6 +8,8 @@ A Simple Example Flask Application
 
 # Third Party Libs
 from flask import Flask
+
+# First Party Libs
 from flask_hal import HAL, document
 
 

--- a/examples/hello_world/hello_world.py
+++ b/examples/hello_world/hello_world.py
@@ -15,13 +15,12 @@ app = Flask(__name__)
 HAL(app)  # Initialise HAL
 
 
-@app.route('/foo')
+@app.route('/hello')
 def foo():
-    d = document.Document(data={
-        'foo': 'bar'
+    return document.Document(data={
+        'message': 'Hello World'
     })
 
-    return d.to_json()
 
 if __name__ == "__main__":
     app.run()

--- a/examples/hello_world/hello_world.py
+++ b/examples/hello_world/hello_world.py
@@ -18,11 +18,11 @@ HAL(app)  # Initialise HAL
 
 
 @app.route('/hello')
-def foo():
+def hello():
     return document.Document(data={
         'message': 'Hello World'
     })
 
 
 if __name__ == "__main__":
-    app.run()
+    app.run(debug=True)

--- a/flask_hal/__init__.py
+++ b/flask_hal/__init__.py
@@ -13,6 +13,8 @@ Read more at the `Official Draft <https://tools.ietf.org/html/draft-kelly-json-h
 
 # Third Party Libs
 from flask import Response
+
+# First Party Libs
 from flask_hal.document import Document
 
 
@@ -79,7 +81,8 @@ class HALResponse(Response):
         >>> app.response_class = HALResponse
     """
 
-    def force_type(self, rv, env):
+    @staticmethod
+    def force_type(rv, env):
         """Called by ``flask.make_response`` when a view returns a none byte,
         string or unicode value. This method takes the views return value
         and converts into a standard `Response`.
@@ -90,10 +93,6 @@ class HALResponse(Response):
 
         Returns:
             flask.wrappers.Response: A standard Flask response
-
-        Raises:
-            TypeError: If the return value of the view is not
-            a :class:`flask_hal.document.Document`
         """
 
         if isinstance(rv, Document):
@@ -103,4 +102,4 @@ class HALResponse(Response):
                     'Content-Type': 'application/hal+json'
                 })
 
-        raise TypeError('{0} is not a flask_hal.document.Document instance')
+        return Response.force_type(rv, env)

--- a/flask_hal/__init__.py
+++ b/flask_hal/__init__.py
@@ -11,6 +11,10 @@ you to build ``REST`` API responses which fulfil this specification.
 Read more at the `Official Draft <https://tools.ietf.org/html/draft-kelly-json-hal-07>`_
 """
 
+# Third Party Libs
+from flask import Response
+from flask_hal.document import Document
+
 
 class HAL(object):
     """Enables Flask-HAL integration into Flask Applications, either by the
@@ -58,3 +62,41 @@ class HAL(object):
         """
 
         pass
+
+
+class HALResponse(Response):
+    """A custom response class which overrides the default Response class
+    wrapper.
+
+    Example:
+        >>> from flask import Flask()
+        >>> from flask_hal import HALResponse
+        >>> app = Flask(__name__)
+        >>> app.response_class = HALResponse
+    """
+
+    def force_type(self, rv, env):
+        """Called by ``flask.make_response`` when a view returns a none byte,
+        string or unicode value. This method takes the views return value
+        and converts into a standard `Response`.
+
+        Args:
+            rv (flask_hal.document.Document): View return value
+            env (dict): Request environment
+
+        Returns:
+            flask.wrappers.Response: A standard Flask response
+
+        Raises:
+            TypeError: If the return value of the view is not
+            a :class:`flask_hal.document.Document`
+        """
+
+        if isinstance(rv, Document):
+            return Response(
+                rv.to_json(),
+                headers={
+                    'Content-Type': 'application/hal+json'
+                })
+
+        raise TypeError('{0} is not a flask_hal.document.Document instance')

--- a/flask_hal/__init__.py
+++ b/flask_hal/__init__.py
@@ -61,7 +61,11 @@ class HAL(object):
             response_class (class): Optional custom ``response_class``
         """
 
-        pass
+        # Set the response class
+        if response_class is None:
+            app.response_class = HALResponse
+        else:
+            app.response_class = response_class
 
 
 class HALResponse(Response):

--- a/flask_hal/document.py
+++ b/flask_hal/document.py
@@ -16,7 +16,7 @@ Example:
 # Standard Libs
 import json
 
-# Third Party Libs
+# First Party Libs
 from flask_hal import link
 
 

--- a/flask_hal/document.py
+++ b/flask_hal/document.py
@@ -38,7 +38,7 @@ class Document(object):
         """
 
         self.data = data
-        self.embedded = embedded  # TODO: Embedded API TBC
+        # self.embedded = embedded  TODO: Embedded API TBC
 
         # No links provided, create an empty collection
         if links is None:
@@ -70,7 +70,7 @@ class Document(object):
         document.update(self.links.to_dict())
 
         # Add Embedded TODO: Embedded API TBC
-        document.update(self.embedded)
+        # document.update(self.embedded)
 
         return document
 


### PR DESCRIPTION
A custom response class which handles converting `flask_hal.document.Document` view return values into standard `flask.Response` objects.

This means views still follow the standard `tuple` return value pattern and can still return none `HAL` document responses if needed.

The user also has the ability to set their own `response_class` if needed.
