### PR TITLE
simplifiing addeding list of links to documents..

### DIFF
--- a/flask_hal/document.py
+++ b/flask_hal/document.py
@@ -51,7 +51,7 @@ class BaseDocument(object):
             if isinstance(value, (list, set, tuple)):
                 value = link.Collection(*value)
             else:
-                raise TypeError('links must be a {} or {} instance'.format(
+                raise TypeError('links must be a {0} or {1} instance'.format(
                                 link.Collection, list))
         self._links = value
 
@@ -62,7 +62,7 @@ class BaseDocument(object):
     @embedded.setter
     def embedded(self, value):
         if not isinstance(value, dict):
-            raise TypeError('embedded must be a {} instance'.format(dict))
+            raise TypeError('embedded must be a {0} instance'.format(dict))
         self._embedded = value
 
     def to_dict(self):
@@ -86,7 +86,9 @@ class BaseDocument(object):
         # Add Embedded: Embedded API TBC
         if self.embedded:
             document.update({
-                '_embedded': {n: v.to_dict() for n, v in self.embedded.items()}
+                '_embedded': dict(
+                    (n, v.to_dict()) for n, v in self.embedded.items()
+                )
             })
 
         return document

--- a/flask_hal/document.py
+++ b/flask_hal/document.py
@@ -48,7 +48,11 @@ class BaseDocument(object):
     @links.setter
     def links(self, value):
         if not isinstance(value, link.Collection):
-            raise TypeError('links must be a {} instance'.format(link.Collection))
+            if isinstance(value, (list, set, tuple)):
+                value = link.Collection(*value)
+            else:
+                raise TypeError('links must be a {} or {} instance'.format(
+                                link.Collection, list))
         self._links = value
 
     @property
@@ -82,7 +86,7 @@ class BaseDocument(object):
         # Add Embedded: Embedded API TBC
         if self.embedded:
             document.update({
-                '_embedded': {n: v.to_dict() for n, v in self.embedded.iteritems()}
+                '_embedded': {n: v.to_dict() for n, v in self.embedded.items()}
             })
 
         return document

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1,0 +1,85 @@
+# Third Party Libs
+import flask
+import pytest
+
+# First Party Libs
+from flask_hal.document import Document, Embedded
+from flask_hal import link
+
+
+def test_document_should_have_link_self():
+    app = flask.Flask(__name__)
+    with app.test_request_context('/entity/231'):
+        document = Document()
+        assert flask.request.url == document.links[0].href
+
+
+def test_should_raise_exception_when_links_are_not_in_collection():
+    app = flask.Flask(__name__)
+    with app.test_request_context('/entity/231'):
+        with pytest.raises(TypeError):
+            Document(links=link.Link('foo', 'www.foo.com'))
+
+
+def test_should_append_embedded_document():
+    app = flask.Flask(__name__)
+    with app.test_request_context('/entity/231'):
+        document = Document(
+            embedded={
+                'orders': Embedded(
+                    embedded={'details': Embedded(
+                        data={'details': {}}
+                    )},
+                    links=link.Collection(
+                        link.Link('foo', 'www.foo.com'),
+                        link.Link('boo', 'www.boo.com')
+                    ),
+                    data={'total': 30},
+                )
+            },
+            data={'currentlyProcessing': 14}
+        )
+        expected = {
+            '_links': {
+                'self': {
+                    'href': flask.request.url
+                }
+            },
+            '_embedded': {
+                'orders': {
+                    '_links': {
+                        'foo': {'href': 'www.foo.com'},
+                        'boo': {'href': 'www.boo.com'}
+                    },
+                    '_embedded': {
+                        'details': {'details': {}}
+                    },
+                    'total': 30,
+                }
+            },
+            'currentlyProcessing': 14
+        }
+        assert expected == document.to_dict()
+
+
+def test_document_link_as_list_is_converted_to_collection():
+    app = flask.Flask(__name__)
+    with app.test_request_context('/entity/231'):
+        document = Document(links=[link.Link('foo', 'www.foo.com')])
+        assert isinstance(document.links, link.Collection)
+        assert 2 == len(document.links)
+
+
+def test_empty_document_to_json():
+    app = flask.Flask(__name__)
+    with app.test_request_context('/foo/23'):
+        document = Document()
+        expected = '{"_links": {"self": {"href": "http://localhost/foo/23"}}}'
+        assert expected == document.to_json()
+
+
+def test_should_raise_exception_when_embedded_is_not_dict():
+    app = flask.Flask(__name__)
+    with app.test_request_context('/entity/231'):
+        with pytest.raises(TypeError):
+            Document(embedded=['details'])


### PR DESCRIPTION
Now you can do:

``` python
Document(links=[link.Link('foo', 'www.foo.com')])
```

Instead of:

``` python
Document(links=link.Collection(link.Link('foo', 'www.foo.com')))
```
