### PR TITLE
Tests: Unittests for link module

### DIFF
--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -12,10 +12,59 @@ Unittests for the :module:`flask_hal.link` module.
 import json
 
 # Third Party Libs
+import pytest
 from flask import Flask
 
 # First Party Libs
-from flask_hal.link import Link, Self
+from flask_hal.link import Collection, Link, Self
+
+
+class TestCollection(object):
+
+    def test_init_raises_type_error(self):
+        with pytest.raises(TypeError) as excinfo:
+            Collection(
+                Link('foo', '/foo'),
+                'Foo',
+                Link('bar', '/bar'))
+
+        assert 'Foo is not a valid flask_hal.link.Link instance' in str(excinfo.value)
+
+    def test_to_dict(self):
+        c = Collection(
+            Link('foo', '/foo'),
+            Link('bar', '/bar'))
+
+        expected = {
+            '_links': {
+                'foo': {
+                    'href': '/foo'
+                },
+                'bar': {
+                    'href': '/bar'
+                }
+            }
+        }
+
+        assert c.to_dict() == expected
+
+    def test_to_json(self):
+        c = Collection(
+            Link('foo', '/foo'),
+            Link('bar', '/bar'))
+
+        expected = json.dumps({
+            '_links': {
+                'foo': {
+                    'href': '/foo'
+                },
+                'bar': {
+                    'href': '/bar'
+                }
+            }
+        })
+
+        assert c.to_json() == expected
 
 
 class TestLink(object):

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+"""
+tests.test_link
+===============
+
+Unittests for the :module:`flask_hal.link` module.
+"""
+
+# Standard Libs
+import json
+
+# First Party Libs
+from flask_hal.link import Link
+
+
+class TestLink(object):
+
+    def test_only_valid_link_attrs_set(self):
+        l = Link('foo', '/foo', foo='foo', name='foo')
+
+        assert not hasattr(l, 'foo')
+        assert l.name == 'foo'
+
+    def test_to_dict(self):
+        l = Link('foo', '/foo', foo='foo', name='foo')
+
+        expected = {
+            'foo': {
+                'href': '/foo',
+                'name': 'foo',
+            }
+        }
+
+        assert l.to_dict() == expected
+
+    def test_to_json(self):
+        l = Link('foo', '/foo', foo='foo', name='foo')
+
+        expected = json.dumps({
+            'foo': {
+                'href': '/foo',
+                'name': 'foo',
+            }
+        })
+
+        assert l.to_json() == expected

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -11,8 +11,11 @@ Unittests for the :module:`flask_hal.link` module.
 # Standard Libs
 import json
 
+# Third Party Libs
+from flask import Flask
+
 # First Party Libs
-from flask_hal.link import Link
+from flask_hal.link import Link, Self
 
 
 class TestLink(object):
@@ -46,3 +49,42 @@ class TestLink(object):
         })
 
         assert l.to_json() == expected
+
+
+class TestSelf(object):
+
+    def setup(self):
+        self.app = Flask(__name__)
+
+    def test_only_valid_link_attrs_set(self):
+        with self.app.test_request_context():
+            l = Self(foo='foo', name='foo')
+
+            assert not hasattr(l, 'foo')
+            assert l.name == 'foo'
+
+    def test_to_dict(self):
+        with self.app.test_request_context():
+            l = Self(foo='foo', name='foo')
+
+            expected = {
+                'self': {
+                    'href': 'http://localhost/',
+                    'name': 'foo',
+                }
+            }
+
+            assert l.to_dict() == expected
+
+    def test_to_json(self):
+        with self.app.test_request_context():
+            l = Self(foo='foo', name='foo')
+
+            expected = json.dumps({
+                'self': {
+                    'href': 'http://localhost/',
+                    'name': 'foo',
+                }
+            })
+
+            assert l.to_json() == expected

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py26, py27, py33, py34
 
 [testenv]
 deps=
+    flask
     pytest
     pytest-cov
     pytest-pep8
@@ -11,6 +12,7 @@ commands=py.test tests
 
 [testenv:py26]
 deps=
+    flask
     pytest
     pytest-cov
     pytest-pep8


### PR DESCRIPTION
Adds simple standard unittests for the `flask_hal.link` module.
