### PR TITLE
Embbeded documetn can have data also in a list

### DIFF
--- a/flask_hal/document.py
+++ b/flask_hal/document.py
@@ -162,4 +162,15 @@ class Embedded(BaseDocument):
                 "currentlyProcessing": 14
             }
     """
-    pass
+
+    def to_dict(self):
+        """Converts the ``Document`` instance into an appropriate data
+        structure for HAL formatted documents.
+
+        Returns:
+            dict: The ``HAL`` document data structure
+        """
+        if isinstance(self.data, (list, tuple, set)):
+            return self.data
+
+        return super(Embedded, self).to_dict()

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -83,3 +83,44 @@ def test_should_raise_exception_when_embedded_is_not_dict():
     with app.test_request_context('/entity/231'):
         with pytest.raises(TypeError):
             Document(embedded=['details'])
+
+
+def test_data_in_embedded_can_be_array():
+    app = flask.Flask(__name__)
+    with app.test_request_context('/entity/231'):
+        document = Document(
+            embedded={
+                'order': Embedded(
+                    data=[
+                        {
+                            'total': 30.00,
+                            'currency': 'USD',
+                            'status': 'shipped'
+                        }, {
+                            'total': 20.00,
+                            'currency': 'USD',
+                            'status': 'processing'
+                        }
+                    ]
+                )
+            },
+            data={
+                'currentlyProcessing': 14
+            }
+        )
+        expected = {
+            'currentlyProcessing': 14,
+            '_links': {'self': {'href': u'http://localhost/entity/231'}},
+            '_embedded': {
+                'order': [{
+                    'total': 30.00,
+                    'currency': 'USD',
+                    'status': 'shipped'
+                }, {
+                    'total': 20.00,
+                    'currency': 'USD',
+                    'status': 'processing'
+                }]
+            }
+        }
+        assert expected == document.to_dict()


### PR DESCRIPTION
List in HAS are in embedded object which wasn't supported as default.. An another nested `dict` had to be used.

``` json
{
    "_links": {
        "self": { "href": "/orders" },
        "curies": [{ "name": "ea", "href": "http://example.com/docs/rels/{rel}", "templated": true }],
        "next": { "href": "/orders?page=2" },
        "ea:find": {
            "href": "/orders{?id}",
            "templated": true
        },
        "ea:admin": [{
            "href": "/admins/2",
            "title": "Fred"
        }, {
            "href": "/admins/5",
            "title": "Kate"
        }]
    },
    "currentlyProcessing": 14,
    "shippedToday": 20,
    "_embedded": {
        "ea:order": [{
            "_links": {
                "self": { "href": "/orders/123" },
                "ea:basket": { "href": "/baskets/98712" },
                "ea:customer": { "href": "/customers/7809" }
            },
            "total": 30.00,
            "currency": "USD",
            "status": "shipped"
        }, {
            "_links": {
                "self": { "href": "/orders/124" },
                "ea:basket": { "href": "/baskets/97213" },
                "ea:customer": { "href": "/customers/12369" }
            },
            "total": 20.00,
            "currency": "USD",
            "status": "processing"
        }]
    }
}
```
