### PR TITLE
Fix: Self and SERVER_NAME

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Change Log
 ----------
 
+Pending
+~~~~~~~~~
+- ``self`` links now take into account ``SERVER_NAME`` configuration
+
 1.0.0
 ~~~~~~~~~
 - A list can be used in data for Embedded object

--- a/flask_hal/document.py
+++ b/flask_hal/document.py
@@ -145,7 +145,7 @@ class Embedded(BaseDocument):
         >>> document.to_json()
         ... {
                 "_links": {
-                    "self": {"href": "http://localhost/entity/231"}
+                    "self": {"href": "/entity/231"}
                 },
                 "_embedded": {
                     "orders": {

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -12,7 +12,7 @@ Implements the ``HAL`` Link specification.
 import json
 
 # Third Party Libs
-from flask import request
+from flask import current_app, request
 
 
 VALID_LINK_ATTRS = [
@@ -208,4 +208,8 @@ class Self(Link):
             :class:`.Link`
         """
 
-        return super(Self, self).__init__('self', request.url, **kwargs)
+        url = request.url
+        if current_app.config['SERVER_NAME'] is None:
+            url = request.url.replace(request.host_url, '/')
+
+        return super(Self, self).__init__('self', url, **kwargs)

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -3,15 +3,15 @@ import flask
 import pytest
 
 # First Party Libs
-from flask_hal.document import Document, Embedded
 from flask_hal import link
+from flask_hal.document import Document, Embedded
 
 
 def test_document_should_have_link_self():
     app = flask.Flask(__name__)
     with app.test_request_context('/entity/231'):
         document = Document()
-        assert flask.request.url == document.links[0].href
+        assert flask.request.path == document.links[0].href
 
 
 def test_should_raise_exception_when_links_are_not_in_collection():
@@ -42,7 +42,7 @@ def test_should_append_embedded_document():
         expected = {
             '_links': {
                 'self': {
-                    'href': flask.request.url
+                    'href': flask.request.path
                 }
             },
             '_embedded': {
@@ -74,7 +74,7 @@ def test_empty_document_to_json():
     app = flask.Flask(__name__)
     with app.test_request_context('/foo/23'):
         document = Document()
-        expected = '{"_links": {"self": {"href": "http://localhost/foo/23"}}}'
+        expected = '{"_links": {"self": {"href": "/foo/23"}}}'
         assert expected == document.to_json()
 
 
@@ -110,7 +110,7 @@ def test_data_in_embedded_can_be_array():
         )
         expected = {
             'currentlyProcessing': 14,
-            '_links': {'self': {'href': u'http://localhost/entity/231'}},
+            '_links': {'self': {'href': u'/entity/231'}},
             '_embedded': {
                 'order': [{
                     'total': 30.00,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -44,7 +44,7 @@ class TestHalResponse(object):
         expected = json.dumps({
             '_links': {
                 'self': {
-                    'href': 'http://localhost/'
+                    'href': '/'
                 }
             }
         })

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -118,7 +118,7 @@ class TestSelf(object):
 
             expected = {
                 'self': {
-                    'href': 'http://localhost/',
+                    'href': '/',
                     'name': 'foo',
                 }
             }
@@ -131,9 +131,23 @@ class TestSelf(object):
 
             expected = json.dumps({
                 'self': {
-                    'href': 'http://localhost/',
+                    'href': '/',
                     'name': 'foo',
                 }
             })
 
             assert l.to_json() == expected
+
+    def test_with_server_name(self):
+        self.app.config['SERVER_NAME'] = 'foo.com'
+        with self.app.test_request_context():
+            l = Self(foo='foo', name='foo')
+
+            expected = {
+                'self': {
+                    'href': 'http://foo.com/',
+                    'name': 'foo',
+                }
+            }
+
+            assert l.to_dict() == expected


### PR DESCRIPTION
The `http://server_name` for `self` links should only be applied when `SERVER_NAME` is configured in the Flask Application config.
