### PR TITLE
Correctly deserialise embedded documents

### DIFF
--- a/flask_hal/document.py
+++ b/flask_hal/document.py
@@ -171,6 +171,13 @@ class Embedded(BaseDocument):
             dict: The ``HAL`` document data structure
         """
         if isinstance(self.data, (list, tuple, set)):
-            return self.data
+            data = []
+
+            for item in self.data:
+                if isinstance(item, BaseDocument):
+                    data.append(item.to_dict())
+                else:
+                    data.append(item)
+            return data
 
         return super(Embedded, self).to_dict()

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -124,3 +124,68 @@ def test_data_in_embedded_can_be_array():
             }
         }
         assert expected == document.to_dict()
+
+
+def test_data_in_embedded_can_be_array_of_documents():
+    app = flask.Flask(__name__)
+    with app.test_request_context('/entity/231'):
+        document = Document(
+            embedded={
+                'order': Embedded(
+                    data=[
+                        Embedded(
+                            data={
+                                'total': 30.00,
+                                'currency': 'USD',
+                                'status': 'shipped'
+                            },
+                            links=link.Collection(
+                                link.Link('foo', 'www.foo30.com'),
+                                link.Link('boo', 'www.boo30.com')
+                            ),
+                        ),
+                        Embedded(
+                            data={
+                                'total': 20.00,
+                                'currency': 'USD',
+                                'status': 'processing'
+                            },
+                            links=link.Collection(
+                                link.Link('foo', 'www.foo20.com'),
+                                link.Link('boo', 'www.boo20.com')
+                            ),
+                        )
+                    ]
+                )
+            },
+            data={
+                'currentlyProcessing': 14
+            }
+        )
+        expected = {
+            'currentlyProcessing': 14,
+            '_links': {'self': {'href': u'/entity/231'}},
+            '_embedded': {
+                'order': [
+                    {
+                        '_links': {
+                            'foo': {'href': 'www.foo30.com'},
+                            'boo': {'href': 'www.boo30.com'}
+                        },
+                        'total': 30.00,
+                        'currency': 'USD',
+                        'status': 'shipped'
+                    },
+                    {
+                        '_links': {
+                            'foo': {'href': 'www.foo20.com'},
+                            'boo': {'href': 'www.boo20.com'}
+                        },
+                        'total': 20.00,
+                        'currency': 'USD',
+                        'status': 'processing'
+                    }
+                ]
+            }
+        }
+        assert expected == document.to_dict()


### PR DESCRIPTION
Fixes the `to_dict` of `EmbeddedDocument` which was not `to_dict`ing on it's embeded documents.

Without this it is not possible to support documents like below (which is taken from the [HAL spec](https://tools.ietf.org/html/draft-kelly-json-hal-08#section-6)):

```
   {
     "_links": {
       "self": { "href": "/orders" },
       "next": { "href": "/orders?page=2" },
       "find": { "href": "/orders{?id}", "templated": true }
     },
     "_embedded": {
       "orders": [{
           "_links": {
             "self": { "href": "/orders/123" },
             "basket": { "href": "/baskets/98712" },
             "customer": { "href": "/customers/7809" }
           },
           "total": 30.00,
           "currency": "USD",
           "status": "shipped",
         },{
           "_links": {
             "self": { "href": "/orders/124" },
             "basket": { "href": "/baskets/97213" },
             "customer": { "href": "/customers/12369" }
           },
           "total": 20.00,
           "currency": "USD",
           "status": "processing"
       }]
     },
     "currentlyProcessing": 14,
     "shippedToday": 20
   }
```
