### PR TITLE
allow for self link to use a fully-qualified url

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -6,6 +6,7 @@ Contributors
 * Greg Reed: `@peeklondon <http://github.com/peeklondon>`_
 * Brian Peters: `@brianfpeters <http://github.com/brianfpeters>`_
 * Craig Blaszczyk: `@jakul <https://github.com/jakul>`_
+* Jason Jones: `@jcjones1515 <https://github.com/jcjones1515>`_
 
 Special Thanks
 --------------

--- a/flask_hal/document.py
+++ b/flask_hal/document.py
@@ -107,7 +107,7 @@ class Document(BaseDocument):
     """Constructs a ``HAL`` document.
     """
 
-    def __init__(self, data=None, links=None, embedded=None):
+    def __init__(self, data=None, links=None, embedded=None, external_self=False):
         """Initialises a new ``HAL`` Document instance. If no arguments are
         provided a minimal viable ``HAL`` Document is created.
 
@@ -115,12 +115,13 @@ class Document(BaseDocument):
             data (dict): Data for the document
             links (flask_hal.link.Collection): A collection of ``HAL`` links
             embedded: TBC
+            external_self: use a fully-qualified link for self
 
         Raises:
             TypeError: If ``links`` is not a :class:`flask_hal.link.Collection`
         """
         super(Document, self).__init__(data, links, embedded)
-        self.links.append(link.Self())
+        self.links.append(link.Self(external=external_self))
 
 
 class Embedded(BaseDocument):

--- a/flask_hal/link.py
+++ b/flask_hal/link.py
@@ -209,12 +209,16 @@ class Self(Link):
         """Initialises a new ``Self`` link instance. Accepts the same
         Keyword Arguments as :class:`.Link`.
 
+        Additional Keyword Args:
+            external (bool): if true, force link to be fully-qualified URL, defaults to False
+
         See Also:
             :class:`.Link`
         """
 
         url = request.url
-        if current_app.config['SERVER_NAME'] is None:
+        external = kwargs.get('external', False)
+        if not external and current_app.config['SERVER_NAME'] is None:
             url = request.url.replace(request.host_url, '/')
 
         return super(Self, self).__init__('self', url, **kwargs)

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -14,6 +14,13 @@ def test_document_should_have_link_self():
         assert flask.request.path == document.links[0].href
 
 
+def test_document_external_self():
+    app = flask.Flask(__name__)
+    with app.test_request_context('/entity/231'):
+        document = Document(external_self=True)
+        assert flask.request.url == document.links[0].href
+
+
 def test_should_raise_exception_when_links_are_not_in_collection():
     app = flask.Flask(__name__)
     with app.test_request_context('/entity/231'):

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -191,3 +191,15 @@ class TestSelf(object):
             }
 
             assert l.to_dict() == expected
+
+    def test_external(self):
+        with self.app.test_request_context():
+            l = Self(external=True)
+
+            expected = {
+                'self': {
+                    'href': 'http://localhost/'
+                }
+            }
+
+            assert l.to_dict() == expected


### PR DESCRIPTION
adds an optional keyword to Documents to make self links fully-qualified

decided to use the keyword "external", as this is the terminology used by Flask’s url_for function