### PR TITLE
add convenience attribute to BaseDcoument for getting self link

### DIFF
--- a/flask_hal/document.py
+++ b/flask_hal/document.py
@@ -56,6 +56,20 @@ class BaseDocument(object):
         self._links = value
 
     @property
+    def self_link(self):
+        """Returns:
+        Link object for 'self' if found, otherwise returns None
+        """
+        if not self._links:
+            return None
+
+        for l in self._links:
+            if l and (isinstance(l, link.Self) or l.rel == 'self'):
+                return l
+
+        return None
+
+    @property
     def embedded(self):
         return self._embedded
 

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -15,6 +15,14 @@ def test_document_should_have_link_self():
         assert flask.request.path == document.self_link.href  # test self_link property
 
 
+def test_embed_should_not_have_link_self():
+    app = flask.Flask(__name__)
+    with app.test_request_context('/entity/231'):
+        embed = Embedded()
+        assert len(embed.links) == 0
+        assert embed.self_link is None  # test self_link property
+
+
 def test_document_external_self():
     app = flask.Flask(__name__)
     with app.test_request_context('/entity/231'):

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -12,6 +12,7 @@ def test_document_should_have_link_self():
     with app.test_request_context('/entity/231'):
         document = Document()
         assert flask.request.path == document.links[0].href
+        assert flask.request.path == document.self_link.href  # test self_link property
 
 
 def test_document_external_self():


### PR DESCRIPTION
`self_link` attribute will return `None` if no links are found or if no self link is found, otherwise it will return the `Link` object for the self link